### PR TITLE
Add bloco logo to TUI displays

### DIFF
--- a/internal/tui/benchmark.go
+++ b/internal/tui/benchmark.go
@@ -196,6 +196,10 @@ func (m BenchmarkModel) View() string {
 func (m BenchmarkModel) renderProgressView() string {
 	var b strings.Builder
 
+	pad := strings.Repeat(" ", padding)
+	b.WriteString(renderBlocoLogo(pad))
+	b.WriteString("\n")
+
 	// Header
 	header := m.styleManager.FormatHeader("🏃 Benchmark Running")
 	b.WriteString(header + "\n\n")
@@ -298,6 +302,10 @@ func (m BenchmarkModel) renderTransitionView() string {
 // renderResultsView renders the benchmark results table
 func (m BenchmarkModel) renderResultsView() string {
 	var b strings.Builder
+
+	pad := strings.Repeat(" ", padding)
+	b.WriteString(renderBlocoLogo(pad))
+	b.WriteString("\n")
 
 	// Header
 	header := m.styleManager.FormatHeader("📈 Benchmark Results")

--- a/internal/tui/logo.go
+++ b/internal/tui/logo.go
@@ -1,0 +1,23 @@
+package tui
+
+import "strings"
+
+var blocoLogoLines = []string{
+	" _________  ____       _________  __________ _________",
+	"|     o   )/   /_____ /    O    \\/   /_____//    O    \\",
+	"|_____O___)\\___\\_____\\\\_________/\\___\\%%%%%'\\_________/",
+	" `BBBBBBB'  `BBBBBBBB' `BBBBBBB'  `BBBBBBBB' `BBBBBBB'",
+}
+
+func renderBlocoLogo(pad string) string {
+	var b strings.Builder
+	for _, line := range blocoLogoLines {
+		if len(line) == 0 {
+			continue
+		}
+		b.WriteString(pad)
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/tui/logo.go
+++ b/internal/tui/logo.go
@@ -11,8 +11,15 @@ var blocoLogoLines = []string{
 
 func renderBlocoLogo(pad string) string {
 	var b strings.Builder
+func renderBlocoLogo(pad string) string {
+	var b strings.Builder
 	for _, line := range blocoLogoLines {
-		if len(line) == 0 {
+		b.WriteString(pad)
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
 			continue
 		}
 		b.WriteString(pad)

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -269,6 +269,8 @@ func (m ProgressModel) View() string {
 
 	// Title section
 	content.WriteString("\n")
+	content.WriteString(renderBlocoLogo(pad))
+	content.WriteString("\n")
 	content.WriteString(pad)
 	content.WriteString(m.styleManager.FormatTitle("🎯 Bloco Wallet Generation"))
 	content.WriteString("\n\n")

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -270,12 +270,10 @@ func (m ProgressModel) View() string {
 	// Title section
 	content.WriteString("\n")
 	content.WriteString(renderBlocoLogo(pad))
-	content.WriteString("\n")
+ content.WriteString("\n")
 	content.WriteString(pad)
-	content.WriteString(m.styleManager.FormatTitle("🎯 Bloco Wallet Generation"))
+	content.WriteString(m.styleManager.FormatTitle(" Wallet Generator"))
 	content.WriteString("\n\n")
-
-	// ALWAYS show progress information first (pattern, difficulty, progress bar, stats)
 
 	// Pattern information
 	content.WriteString(pad)
@@ -506,9 +504,10 @@ func (m *ProgressModel) updateResultsTable() {
 			// }
 
 			privateKey := result.PrivateKey
-			if len(privateKey) > 60 {
-				privateKey = privateKey[:60] + "..." // Truncate long private keys
-			}
+      // Dont truncate Etherem private keys
+      //if len(privateKey) > 60 {
+			//	privateKey = privateKey[:60] + "..." // Truncate long private keys
+			//}
 
 			rows = append(rows, table.Row{
 				fmt.Sprintf("%d", result.Index),

--- a/internal/tui/stats.go
+++ b/internal/tui/stats.go
@@ -157,6 +157,8 @@ func (m StatsModel) View() string {
 
 	// Title
 	content.WriteString("\n")
+	content.WriteString(renderBlocoLogo(pad))
+	content.WriteString("\n")
 	content.WriteString(pad)
 	content.WriteString(m.styleManager.FormatTitle("📊 Bloco Address Difficulty Analysis"))
 	content.WriteString("\n\n")


### PR DESCRIPTION
## Summary
- add a shared bloco ASCII logo helper for the TUI
- render the logo at the top of the progress, benchmark, and stats views

## Testing
- go test ./internal/tui...


------
https://chatgpt.com/codex/tasks/task_e_68ccc206c3cc8331b0f36b6884a370d3