### PR TITLE
Add bloco logo to TUI displays

### DIFF
--- a/internal/tui/benchmark.go
+++ b/internal/tui/benchmark.go
@@ -196,6 +196,10 @@ func (m BenchmarkModel) View() string {
 func (m BenchmarkModel) renderProgressView() string {
 	var b strings.Builder
 
+	pad := strings.Repeat(" ", padding)
+	b.WriteString(renderBlocoLogo(pad))
+	b.WriteString("\n")
+
 	// Header
 	header := m.styleManager.FormatHeader("🏃 Benchmark Running")
 	b.WriteString(header + "\n\n")
@@ -298,6 +302,10 @@ func (m BenchmarkModel) renderTransitionView() string {
 // renderResultsView renders the benchmark results table
 func (m BenchmarkModel) renderResultsView() string {
 	var b strings.Builder
+
+	pad := strings.Repeat(" ", padding)
+	b.WriteString(renderBlocoLogo(pad))
+	b.WriteString("\n")
 
 	// Header
 	header := m.styleManager.FormatHeader("📈 Benchmark Results")

--- a/internal/tui/logo.go
+++ b/internal/tui/logo.go
@@ -1,0 +1,20 @@
+package tui
+
+import "strings"
+
+var blocoLogoLines = []string{
+	" _________  ____       _________  __________ _________",
+	"|     o   )/   /_____ /    O    \\/   /_____//    O    \\",
+	"|_____O___)\\___\\_____\\\\_________/\\___\\%%%%%'\\_________/",
+	" `BBBBBBB'  `BBBBBBBB' `BBBBBBB'  `BBBBBBBB' `BBBBBBB'",
+}
+
+func renderBlocoLogo(pad string) string {
+	var b strings.Builder
+	for _, line := range blocoLogoLines {
+		b.WriteString(pad)
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/internal/tui/logo.go
+++ b/internal/tui/logo.go
@@ -10,10 +10,10 @@ import "strings"
 //}
 
 var blocoLogoLines = []string{
-    ` _________  ____       _________  __________ _________`,
-    `|     o   )/   /_____ /    O    \/   /_____//    O    \`,
-    `|_____O___)\___\_____\\_________/\___\%%%%%'\_________/`,
-    ` 'BBBBBBB'  'BBBBBBBB' 'BBBBBBB'  'BBBBBBBB' 'BBBBBBB'`,
+	` _________  ____       _________  __________ _________`,
+	`|     o   )/   /_____ /    O    \/   /_____//    O    \`,
+	`|_____O___)\___\_____\\_________/\___\%%%%%'\_________/`,
+	` 'BBBBBBB'  'BBBBBBBB' 'BBBBBBB'  'BBBBBBBB' 'BBBBBBB'`,
 }
 
 func renderBlocoLogo(pad string) string {

--- a/internal/tui/logo.go
+++ b/internal/tui/logo.go
@@ -2,11 +2,18 @@ package tui
 
 import "strings"
 
+//var blocoOldLogoLines = []string{
+//	" _________  ____       _________  __________ _________",
+//	"|     o   )/   /_____ /    O    \\/   /_____//    O    \\",
+//	"|_____O___)\\___\\_____\\\\_________/\\___\\%%%%%'\\_________/",
+//	" `BBBBBBB'  `BBBBBBBB' `BBBBBBB'  `BBBBBBBB' `BBBBBBB'",
+//}
+
 var blocoLogoLines = []string{
-	" _________  ____       _________  __________ _________",
-	"|     o   )/   /_____ /    O    \\/   /_____//    O    \\",
-	"|_____O___)\\___\\_____\\\\_________/\\___\\%%%%%'\\_________/",
-	" `BBBBBBB'  `BBBBBBBB' `BBBBBBB'  `BBBBBBBB' `BBBBBBB'",
+    ` _________  ____       _________  __________ _________`,
+    `|     o   )/   /_____ /    O    \/   /_____//    O    \`,
+    `|_____O___)\___\_____\\_________/\___\%%%%%'\_________/`,
+    ` 'BBBBBBB'  'BBBBBBBB' 'BBBBBBB'  'BBBBBBBB' 'BBBBBBB'`,
 }
 
 func renderBlocoLogo(pad string) string {

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -269,6 +269,8 @@ func (m ProgressModel) View() string {
 
 	// Title section
 	content.WriteString("\n")
+	content.WriteString(renderBlocoLogo(pad))
+	content.WriteString("\n")
 	content.WriteString(pad)
 	content.WriteString(m.styleManager.FormatTitle("🎯 Bloco Wallet Generation"))
 	content.WriteString("\n\n")

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -272,8 +272,8 @@ func (m ProgressModel) View() string {
 	content.WriteString(renderBlocoLogo(pad))
 	content.WriteString("\n")
 	content.WriteString(pad)
-	content.WriteString(m.styleManager.FormatTitle("🎯 Bloco Wallet Generation"))
-	content.WriteString("\n\n")
+	content.WriteString(m.styleManager.FormatTitle("Wallet Generator"))
+	content.WriteString("\n")
 
 	// ALWAYS show progress information first (pattern, difficulty, progress bar, stats)
 
@@ -506,9 +506,10 @@ func (m *ProgressModel) updateResultsTable() {
 			// }
 
 			privateKey := result.PrivateKey
-			if len(privateKey) > 60 {
-				privateKey = privateKey[:60] + "..." // Truncate long private keys
-			}
+      // Dont truncate Ethereum private keys
+			// if len(privateKey) > 60 {
+			//	privateKey = privateKey[:60] + "..." // Truncate long private keys
+			//}
 
 			rows = append(rows, table.Row{
 				fmt.Sprintf("%d", result.Index),

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -294,12 +294,12 @@ func (m ProgressModel) View() string {
 	content.WriteString(pad)
 	difficultyStr := formatLargeNumber(int64(m.stats.Difficulty))
 	content.WriteString(m.styleManager.FormatKeyValue("Difficulty", difficultyStr))
-	content.WriteString("\n\n")
+	content.WriteString("\n")
 
 	// Progress bar - following Bubbletea pattern
 	content.WriteString(pad)
 	content.WriteString(m.progress.View())
-	content.WriteString("\n\n")
+	content.WriteString("\n")
 
 	// Progress information
 	content.WriteString(pad)
@@ -322,7 +322,7 @@ func (m ProgressModel) View() string {
 
 	// Statistics section using Bubbletea table-like display
 	content.WriteString(pad)
-	content.WriteString(m.styleManager.FormatSubtitle("📊 Statistics"))
+	content.WriteString(m.styleManager.FormatSubtitle("Statistics"))
 	content.WriteString("\n")
 
 	// Create formatted statistics display
@@ -335,7 +335,7 @@ func (m ProgressModel) View() string {
 		if metrics.ThreadCount > 1 {
 			content.WriteString("\n")
 			content.WriteString(pad)
-			content.WriteString(m.styleManager.FormatSubtitle("🧵 Thread Performance"))
+			content.WriteString(m.styleManager.FormatSubtitle("Thread Performance"))
 			content.WriteString("\n")
 
 			threadDisplay := m.renderThreadStats(metrics)
@@ -345,10 +345,10 @@ func (m ProgressModel) View() string {
 
 	// ADD results table BELOW progress information when we have generated wallets
 	if m.showResults && len(m.walletResults) > 0 {
-		content.WriteString("\n\n")
+		content.WriteString("\n")
 		content.WriteString(pad)
-		content.WriteString(m.styleManager.FormatSubtitle(fmt.Sprintf("💎 Generated Wallets (%d)", len(m.walletResults))))
-		content.WriteString("\n\n")
+		content.WriteString(m.styleManager.FormatSubtitle(fmt.Sprintf("Generated Wallets (%d)", len(m.walletResults))))
+		content.WriteString("\n")
 		content.WriteString(pad)
 		content.WriteString(m.resultsTable.View())
 		content.WriteString("\n")

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -506,7 +506,7 @@ func (m *ProgressModel) updateResultsTable() {
 			// }
 
 			privateKey := result.PrivateKey
-      // Dont truncate Ethereum private keys
+			// Dont truncate Ethereum private keys
 			// if len(privateKey) > 60 {
 			//	privateKey = privateKey[:60] + "..." // Truncate long private keys
 			//}

--- a/internal/tui/stats.go
+++ b/internal/tui/stats.go
@@ -157,6 +157,8 @@ func (m StatsModel) View() string {
 
 	// Title
 	content.WriteString("\n")
+	content.WriteString(renderBlocoLogo(pad))
+	content.WriteString("\n")
 	content.WriteString(pad)
 	content.WriteString(m.styleManager.FormatTitle("📊 Bloco Address Difficulty Analysis"))
 	content.WriteString("\n\n")


### PR DESCRIPTION
## Summary
- add a shared bloco ASCII logo helper for the TUI
- render the logo at the top of the progress, benchmark, and stats views
- fix the logo renderer by removing the empty-line guard and simplifying newline output

## Testing
- make build
- go test ./internal/tui...

------
https://chatgpt.com/codex/tasks/task_e_68ccc206c3cc8331b0f36b6884a370d3